### PR TITLE
[OC-40915] Improve GitHub Actions efficiency 

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,5 +1,9 @@
 name: Unit test
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,6 +1,10 @@
 name: Unit test
 on: [push, pull_request]
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-test:
     name: Check unit test

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   unit-test:
     name: Check unit test
+    timeout-minutes: 30
     runs-on: macos-11
     steps:
       - name: Set Xcode

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,5 +22,8 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v2
 
+      - name: Install xcbeautify
+        run: brew install xcbeautify
+
       - name: Run unit test
         run: ./Tools/Test/run-unit-tests.sh

--- a/Tools/Test/run-unit-tests.sh
+++ b/Tools/Test/run-unit-tests.sh
@@ -5,4 +5,4 @@ DERIVED_DATA_DIR="$PWD/XcodeDerivedData"
 xcodebuild test \
 	-workspace material-carthage-ios.xcworkspace \
 	-scheme material-carthage-ios \
-	-destination 'platform=iOS Simulator,name=iPhone 13,OS=15.2' | xcpretty && exit ${PIPESTATUS[0]}
+	-destination 'platform=iOS Simulator,name=iPhone 13,OS=15.2' 2>&1 | xcbeautify && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
I realised that I forgot to apply the GitHub Actions efficiency changes in this repository.
Nothing new, just replicating what have been done in other repositories. There is maybe an argument for not switching to `xcbeautify` since there is only one test. I added it anyway for consistency with other repositories, and maybe the compilation logs are enough to see a gain?